### PR TITLE
[SNEAKER-176] Add build option to skip running unit test suite during builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 
 script:
   - make gtest
-  - make
+  - make run-test=1
 
 after_success:
   - coveralls --repo-token $COVERALLS_REPO_TOKEN --include ./src/ --include ./include/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (c) 2016 Yanzheng Li
+# Copyright (c) 2017 Yanzheng Li
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -30,6 +30,7 @@ project (sneaker C CXX)
 
 # Options.
 option(RUN_TESTS_ONCE "Run unit test suite once" OFF)
+option(SKIP_TESTS "Skip building and running unit test suite" OFF)
 
 
 # Release mode.
@@ -90,4 +91,6 @@ endif()
 
 # Sub-directories.
 ADD_SUBDIRECTORY(${SRC_DIR})
-ADD_SUBDIRECTORY(${TESTS_DIR})
+if (NOT SKIP_TESTS)
+  ADD_SUBDIRECTORY(${TESTS_DIR})
+endif ()

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2016 Yanzheng Li
+# Copyright (c) 2017 Yanzheng Li
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -64,8 +64,11 @@ LIB_DBG_INSTALL_PATH=$(LIB_INSTALL_DIR)/$(LIBSNEAKER_DBG_A)
 HEADER_INSTALL_PATH=/usr/local/include/sneaker/
 
 
-ifeq ($(fast), 1)
+ifeq ($(run-test), 1)
 	BUILD_TARGET_CMAKE_ARGS=-DRUN_TESTS_ONCE=ON
+endif
+ifeq ($(run-test), 0)
+	BUILD_TARGET_CMAKE_ARGS=-DSKIP_TESTS=ON
 endif
 
 


### PR DESCRIPTION
This patch renames the previous Makefile build option `fast` to `run-test`, which adds greater flexibility and comes with the ability to skip building and running unit test suite all together.

Now, if the option is unspecified, the unit test suite runs 3 times. If the value passed is `1`, it will run exactly once, and finally, if value passed is `0`, the unit test suite will be skipped altogether.